### PR TITLE
Fix apple x86

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -9,6 +9,12 @@ rustflags = [
 "-C", "link-arg=dynamic_lookup",
 ]
 
+[target.x86_64-apple-darwin]
+rustflags = [
+"-C", "link-arg=-undefined",
+"-C", "link-arg=dynamic_lookup",
+]
+
 [profile.release]
 codegen-units = 1
 strip = true


### PR DESCRIPTION
Updates the `.cargo/config` to include Apple-specific linking options.