### PR TITLE
Update Stylus SDK and Use Mini-Alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,6 +1823,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mini-alloc"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9993556d3850cdbd0da06a3dc81297edcfa050048952d84d75e8b944e8f5af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wee_alloc",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,9 +2980,9 @@ dependencies = [
  "ethers",
  "eyre",
  "hex",
+ "mini-alloc",
  "stylus-sdk",
  "tokio",
- "wee_alloc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b0e971622a7a27722c2e3f2658ac4795f00b12a528874c5d08863a2e91eb6e"
+checksum = "12c2d6fedbd0393e2b9f0259ca239c7ede9f87a89933627119b9dc038902d7e9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ description = "Stylus hello world example"
 [dependencies]
 alloy-primitives = "0.3.1"
 alloy-sol-types = "0.3.1"
+mini-alloc = "0.4.2"
 stylus-sdk = "0.4.2"
 hex = "0.4.3"
-wee_alloc = "0.4.5"
 
 [dev-dependencies]
 tokio = { version = "1.12.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Stylus hello world example"
 [dependencies]
 alloy-primitives = "0.3.1"
 alloy-sol-types = "0.3.1"
-stylus-sdk = "0.4.1"
+stylus-sdk = "0.4.2"
 hex = "0.4.3"
 wee_alloc = "0.4.5"
 
@@ -22,6 +22,7 @@ eyre = "0.6.8"
 
 [features]
 export-abi = ["stylus-sdk/export-abi"]
+debug = ["stylus-sdk/debug"]
 
 [[bin]]
 name = "stylus-hello-world"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ extern crate alloc;
 
 /// Initializes a custom, global allocator for Rust programs compiled to WASM.
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
 
 /// Import the Stylus SDK along with alloy primitive types for use in our program.
 use stylus_sdk::{alloy_primitives::U256, prelude::*};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-
 #![cfg_attr(not(feature = "export-abi"), no_main)]
 
 #[cfg(feature = "export-abi")]


### PR DESCRIPTION
This PR updates the hello world repo to use the latest SDK alongside mini-alloc