### PR TITLE
fix func name in Counter example contract

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl Counter {
     }
 
     /// Sets a number in storage to a user-specified value.
-    pub fn sub_number(&mut self, new_number: U256) {
+    pub fn add_number(&mut self, new_number: U256) {
         self.number.set(new_number + self.number.get());
     }
 


### PR DESCRIPTION
## Description

hi I found that the `sub_number` function in the `Counter` example contract actually performs an add operation, so I fixed the function name to make them consistent.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/COPYRIGHT.md
