### PR TITLE
Fixing Rust version to latest stable version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.79.0"


### PR DESCRIPTION
Setting the `rust-toolchain.toml` channel to `1.79.0`
