### PR TITLE
Update example to SDK v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-alloc"
+version = "0.5.2"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs.git?rev=refs/pull/145/head#74593a0b0eccd119f6b870ab3421e9308a8a69a2"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,7 +3243,7 @@ dependencies = [
  "ethers",
  "eyre",
  "hex",
- "mini-alloc",
+ "mini-alloc 0.4.2",
  "stylus-sdk",
  "tokio",
 ]
@@ -3243,8 +3251,7 @@ dependencies = [
 [[package]]
 name = "stylus-proc"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dbf5e4af9b0c0f25877ff19da60ecfd721a0e8fd0a17336892a0d0521648ff"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs.git?rev=refs/pull/145/head#74593a0b0eccd119f6b870ab3421e9308a8a69a2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3262,8 +3269,7 @@ dependencies = [
 [[package]]
 name = "stylus-sdk"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5426b95831da7fde45a91785cafd2121ad8e720b503f0fc7c709667cff5336cf"
+source = "git+https://github.com/OffchainLabs/stylus-sdk-rs.git?rev=refs/pull/145/head#74593a0b0eccd119f6b870ab3421e9308a8a69a2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3272,6 +3278,7 @@ dependencies = [
  "hex",
  "keccak-const",
  "lazy_static",
+ "mini-alloc 0.5.2",
  "regex",
  "stylus-proc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-hello-world"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Stylus hello world example"
 alloy-primitives = "=0.7.6"
 alloy-sol-types = "=0.7.6"
 mini-alloc = "0.4.2"
-stylus-sdk = "0.5.2"
+stylus-sdk = { git = "https://github.com/OffchainLabs/stylus-sdk-rs.git", rev = "refs/pull/145/head" }
 hex = "0.4.3"
 dotenv = "0.15.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylus-hello-world"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/OffchainLabs/stylus-hello-world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Stylus hello world example"
 alloy-primitives = "=0.7.6"
 alloy-sol-types = "=0.7.6"
 mini-alloc = "0.4.2"
-stylus-sdk = { git = "https://github.com/OffchainLabs/stylus-sdk-rs.git", rev = "refs/pull/145/head" }
+stylus-sdk = "0.6.0"
 hex = "0.4.3"
 dotenv = "0.15.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,6 @@
 #![cfg_attr(not(feature = "export-abi"), no_main)]
 extern crate alloc;
 
-/// Use an efficient WASM allocator.
-#[global_allocator]
-static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
-
 /// Import items from the SDK. The prelude contains common traits and macros.
 use stylus_sdk::{alloy_primitives::U256, prelude::*};
 
@@ -42,7 +38,7 @@ sol_storage! {
 }
 
 /// Declare that `Counter` is a contract with the following external methods.
-#[external]
+#[public]
 impl Counter {
     /// Gets the number from storage.
     pub fn number(&self) -> U256 {


### PR DESCRIPTION
Updates the example to be compatible with SDK v0.6.0

NOTE: before merging, the dependency should point at the released crate instead of the git branch.

Marked as draft until the new SDK version is released and the Cargo.toml is updated.