### PR TITLE
docs: remove stylus testnet rpc, add arb sepolia rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ println!("New counter number value = {:?}", num);
 Before running, set the following env vars or place them in a `.env` file (see: [.env.example](./.env.example)) in this project:
 
 ```
-RPC_URL=https://stylus-testnet.arbitrum.io/rpc
+RPC_URL=https://sepolia-rollup.arbitrum.io/rpc
 STYLUS_CONTRACT_ADDRESS=<the onchain address of your deployed program>
 PRIV_KEY_PATH=<the file path for your priv key to transact with>
 ```


### PR DESCRIPTION
## Description

This PR updates the RPC URL in the Stylus-hello-world README from the now-deprecated testnet URL to a Arbitrum Sepolia RPC URL

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/COPYRIGHT.md
