### PR TITLE
Change opt-level from s to 3 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,7 @@ codegen-units = 1
 strip = true
 lto = true
 panic = "abort"
-opt-level = "s"
+
+# If you need to reduce the binary size, it is advisable to try other
+# optimization levels, such as "s" and "z"
+opt-level = 3


### PR DESCRIPTION
In the Rust version used and for this particular contract, the opt-level 3 reduces the binary size in ~400 bytes. That might not always be the case, so also add a comment with a hint near the flag.