### PR TITLE
Make alloy primitives use sha3 keccak in dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hex = "0.4.3"
 dotenv = "0.15.0"
 
 [dev-dependencies]
+alloy-primitives = { version = "=0.8.20", features = ["sha3-keccak"] }
 tokio = { version = "1.12.0", features = ["full"] }
 ethers = "2.0"
 eyre = "0.6.8"


### PR DESCRIPTION
This is important because any code that uses keccak from alloy will try to invoke a native_keccak hostio if this feature is unspecified, causing build failures in test mode