### PR TITLE
Enable bulk-memory for wasm32

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,7 @@
 rustflags = [
   "-C", "link-arg=-zstack-size=32768",
   "-C", "target-feature=-reference-types",
+  "-C", "target-feature=+bulk-memory",
 ]
 
 [target.aarch64-apple-darwin]


### PR DESCRIPTION
## Description

Enabling this feature reduces the contract size.

For example, see gas cost comparison when running benches for OZ contracts:
- `bulk-memory` disabled:
![bulk-memory-disabled](https://github.com/user-attachments/assets/b7699996-c2ec-46aa-b7bb-efa6562c500c)

- `bulk-memory` enabled:
![bulk-memory-enabled](https://github.com/user-attachments/assets/f784aed9-bcc3-4ef1-8418-e83d2da67274)

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-hello-world/blob/main/licenses/COPYRIGHT.md
